### PR TITLE
feat: Replace content type with options param

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@
 [
     ["event.key", {
         "exchange": "event-exchange",
-        "contentType": "application/json",
+        "options": {
+            "contentType": "application/json",
+            "headers": {
+                "streamId": "bloop"
+            },
+        },
         "key": "events.key",
         "data": {
             "Test": "Test"
@@ -18,7 +23,7 @@
     }]
 ]
 ```
-Example event. To add more copy sturcture and add to array
+Example event. To add more copy structure and add to array
 
 ### Environment Variables
 EVENT_CLI_FILE_LOCATION - Location of file that contains events NEEDS TO BE .json

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -9,7 +9,8 @@ export const builder = (yargs: any) => {
         key: { type: 'string', demandOption: true, describe: 'Event routing key', alias: 'k'},
         exchange: { type: 'string', demandOption: true, describe: 'Exchange to publish event', alias: 'ex'},
         alias: { type: 'string', demandOption: true, describe: 'Alias for the key', alias: 'a'},
-        data: { type: 'string', demandOption: true, describe: 'Event data', alias: 'd'}
+        data: { type: 'string', demandOption: true, describe: 'Event data', alias: 'd'},
+        options: { type: 'string', demandOption: false, describe: 'Publish options such as headers and content type', alias: 'o'}
     })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,11 +29,11 @@ const spinner = ora('Running test: ').start();
 (async () => {
     debug('Starting');
 
-    try { 
+    try {
         await RabbitRepository.init();
 
         const publish = new PublishService(RabbitRepository, EventsRepository);
-        
+
         let times = 1;
 
         if (args.times && !isNaN(Number(args.times))) {
@@ -44,9 +44,9 @@ const spinner = ora('Running test: ').start();
             await publish.onPublish(args.keys, times);
         }
     } catch (e) {
-        
+
     }
-    
+
     RabbitRepository.deconstructor();
 
     spinner.stop();

--- a/src/interfaces/IEvent.ts
+++ b/src/interfaces/IEvent.ts
@@ -2,6 +2,6 @@ export default interface IEvent {
 
     exchange: string;
     key: string;
-    contentType: string;
     data: any;
+    options: object;
 }

--- a/src/interfaces/IQueueRepository.ts
+++ b/src/interfaces/IQueueRepository.ts
@@ -1,4 +1,4 @@
 export default interface IQueueRepository {
 
-    publish(exchange: string, key: string, contentType: string, data: object): Promise<void>;
+    publish(exchange: string, key: string, data: object, options: object): Promise<void>;
 }

--- a/src/publish/publish.service.ts
+++ b/src/publish/publish.service.ts
@@ -17,7 +17,6 @@ export class PublishService {
 
         this._debug('onPublish', keys, times)
         const events = this._events.getAll(keys);
-        console.log({keys});
 
         for(const event of events) {
             if (event !== null && event.data !== null) {

--- a/src/publish/publish.service.ts
+++ b/src/publish/publish.service.ts
@@ -17,14 +17,15 @@ export class PublishService {
 
         this._debug('onPublish', keys, times)
         const events = this._events.getAll(keys);
+        console.log({keys});
 
         for(const event of events) {
             if (event !== null && event.data !== null) {
 
                 this._debug('event onPublish');
-    
+
                 for(let i = 0; i < times; i++) {
-                    await this._queue.publish(event.exchange, event.key, event.contentType, event.data)
+                    await this._queue.publish(event.exchange, event.key, event.data, event.options)
                 }
             }
         }

--- a/src/repository/rabbit.repository.ts
+++ b/src/repository/rabbit.repository.ts
@@ -32,7 +32,7 @@ class RabbitRepository implements IQueueRepository {
         }
     }
 
-    async publish(exchange: string, key: string, contentType: string, data: object): Promise<void> {
+    async publish(exchange: string, key: string, data: object, options: object): Promise<void> {
 
         if (this._connection === null || this._connection === undefined) {
             this._debug('Connection undefined')
@@ -44,9 +44,7 @@ class RabbitRepository implements IQueueRepository {
         if (channel) {
             this._debug('created channel');
 
-            const sent = channel.publish(exchange, key, Buffer.from(JSON.stringify(data)), {
-                contentType
-            });
+            const sent = channel.publish(exchange, key, Buffer.from(JSON.stringify(data)), options);
 
             console.log(" [x] Sent %s:'%s' to exchange %s", key, data, exchange);
 


### PR DESCRIPTION
Options is the generic AMQP parameter. Passing options allows us to still pass content type, but also headers and other AMQP publish settings.

This is a breaking change. The config file will need to be updated.